### PR TITLE
Add language toggle

### DIFF
--- a/src/components/features/LikeVideoList/LikeVideoListPresenter.tsx
+++ b/src/components/features/LikeVideoList/LikeVideoListPresenter.tsx
@@ -4,6 +4,7 @@ import VideoItem from "@/components/features/MainVideoList/VideoItem";
 import { Header } from "@/components/ui/Header";
 import { Video } from "@/entities/video/entity";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLanguage } from "@/utils/LanguageContext";
 
 interface LikeVideoListPresenterProps {
   setLikeVideos: React.Dispatch<React.SetStateAction<Video[]>>;
@@ -18,6 +19,7 @@ export function LikeVideoListPresenter({
   likeVideo,
   commentVideo,
 }: LikeVideoListPresenterProps) {
+  const { t } = useLanguage();
   const [isVideoModalOpen, setIsVideoModalOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [activeIndex, setActiveIndex] = useState<number>(0);
@@ -119,7 +121,7 @@ export function LikeVideoListPresenter({
 
           {likeVideos.length === 0 && (
             <div className="flex h-screen items-center justify-center font-bold text-white">
-              いいねした動画はありません
+              {t('noLikedVideos')}
             </div>
           )}
         </div>

--- a/src/components/features/TwitterVideoSave/TwitterVideoSavePresenter.tsx
+++ b/src/components/features/TwitterVideoSave/TwitterVideoSavePresenter.tsx
@@ -1,6 +1,7 @@
 import AdBanner, { JuicyAdsBanner } from "@/components/ads/juicyAds";
 import { Footer } from "@/components/ui/Footer";
 import { Header } from "@/components/ui/Header";
+import { useLanguage } from "@/utils/LanguageContext";
 
 interface TwitterVideoSavePresenterProps {
   getTwitterVideoByUrl: (url: string) => Promise<void>;
@@ -21,13 +22,14 @@ export function TwitterVideoSavePresenter({
   error,
   isLoading,
 }: TwitterVideoSavePresenterProps) {
+  const { t } = useLanguage();
   return (
     <div className="flex min-h-screen flex-col ">
       <Header bgColor="bg-black" />
       <main className="mx-auto w-full max-w-3xl px-4 py-8 pt-24">
         <div className="mb-8 text-center">
           <h1 className="text-2xl font-bold text-gray-900">
-            Twitter動画保存ツール
+            {t('twitterSaveTool')}
           </h1>
           <p className="mt-2 text-sm text-gray-600">
             Twitter（X）に投稿された動画のURLを入力するだけで、簡単に再生＆保存リンクを取得できます。
@@ -41,7 +43,7 @@ export function TwitterVideoSavePresenter({
           >
             <input
               type="text"
-              placeholder="ここにツイートのURLを入力"
+              placeholder={t('tweetUrlPlaceholder')}
               className="h-10 w-full max-w-md rounded-lg border border-gray-300 px-4 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
               value={tweetUrl}
               onChange={(e) => setTweetUrl(e.target.value)}
@@ -50,7 +52,7 @@ export function TwitterVideoSavePresenter({
               type="submit"
               className="h-10 whitespace-nowrap rounded-lg bg-blue-600 px-4 text-white shadow hover:bg-blue-700"
             >
-              取得
+              {t('fetch')}
             </button>
           </form>
           {error && (
@@ -59,7 +61,7 @@ export function TwitterVideoSavePresenter({
           {isLoading && (
             <div className="mt-4 flex flex-col items-center">
               <p className="mb-2 text-sm text-gray-600">
-                動画を取得中です。しばらくお待ちください...
+                {t('fetching')}
               </p>
               <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-gray-500"></div>
             </div>
@@ -69,7 +71,7 @@ export function TwitterVideoSavePresenter({
         {/* 取得した動画のリンクを表示する部分 */}
         {videoUrl !== "" && (
           <div className="mt-8 rounded-lg border border-gray-300 bg-white p-6 shadow">
-            <h2 className=" font-semibold text-gray-900">取得した動画</h2>
+            <h2 className=" font-semibold text-gray-900">{t('fetchedVideo')}</h2>
             <a
               href={videoUrl}
               target="_blank"
@@ -88,10 +90,7 @@ export function TwitterVideoSavePresenter({
         )}
 
         <div className="mt-12 text-xs text-gray-500">
-          <p>
-            ※
-            当サイトは動画ファイルを直接保存しているわけではなく、Twitterに投稿された動画へのリンクを提供しています。
-          </p>
+          <p>{t('note')}</p>
         </div>
       </main>
       <Footer />

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -1,13 +1,16 @@
+import { useLanguage } from "@/utils/LanguageContext";
+
 export function Footer() {
+  const { t } = useLanguage();
   return (
     <footer className="mt-12 w-full bg-gray-100 py-6 px-4 text-sm text-gray-600">
       <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 sm:flex-row">
         <p>&copy; {new Date().getFullYear()} Xroll. All rights reserved.</p>
         <div>
           <a href="/policy" className="hover:underline">
-            プライバシーポリシー
+            {t('privacyPolicy')}
           </a>
-          <div>お問い合わせ：xroll.net@gmail.com</div>
+          <div>{t('contact')}</div>
         </div>
       </div>
     </footer>

--- a/src/components/ui/SideBarMenu.tsx
+++ b/src/components/ui/SideBarMenu.tsx
@@ -11,10 +11,12 @@ import { MdLiveTv } from "react-icons/md";
 
 import { AnimatePresence, motion } from "framer-motion";
 import { Link } from "react-router-dom";
+import { useLanguage } from "@/utils/LanguageContext";
 
 export function SidebarMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { t, toggleLang } = useLanguage();
 
   const toggleMenu = () => setIsOpen(!isOpen);
 
@@ -48,102 +50,112 @@ export function SidebarMenu() {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: -300, opacity: 0 }}
             transition={{ type: "tween" }}
-            className="fixed left-0 top-0 z-50 h-full w-64 bg-black px-3 shadow-lg "
+            className="fixed left-0 top-0 z-50 h-full w-64 bg-black px-3 shadow-lg"
           >
-            <div>
-              <div className="flex gap-3">
-                <button onClick={toggleMenu}>
-                  <IoMdMenu className="h-6 w-6 text-white" />
-                </button>
-                <Link to="/">
-                  <img
-                    src={logo}
-                    alt="Xroll Logo"
-                    className=" h-16 max-h-full object-contain"
-                  />
-                </Link>
-              </div>
+            <div className="flex h-full flex-col justify-between">
+              <div>
+                <div className="flex gap-3">
+                  <button onClick={toggleMenu}>
+                    <IoMdMenu className="h-6 w-6 text-white" />
+                  </button>
+                  <Link to="/">
+                    <img
+                      src={logo}
+                      alt="Xroll Logo"
+                      className=" h-16 max-h-full object-contain"
+                    />
+                  </Link>
+                </div>
 
-              <ul className="space-y-3">
-                {/* <li>
-                  <a
-                    href="https://go.rmhfrtnd.com?userId=3a43ec976d7f513c2bd3e3019041edf8c12c016056dc22074d25c7907abb93fc"
-                    className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <MdLiveTv className="text-white" size={30} />
-                    <span className="text-white">ライブチャット</span>
-                  </a>
-                </li> */}
-                <li>
-                  <a
-                    href="https://go.rmhfrtnd.com?userId=3a43ec976d7f513c2bd3e3019041edf8c12c016056dc22074d25c7907abb93fc"
-                    className="flex items-center gap-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <MdLiveTv className="text-white" size={30} />
-                    <span className="flex items-center gap-1 whitespace-nowrap text-sm text-white">
-                      ライブチャット
-                      <span className="rounded-full bg-red-600 px-2 py-0.5 text-xs text-white">
-                        セール中
+                <ul className="space-y-3">
+                  {/* <li>
+                    <a
+                      href="https://go.rmhfrtnd.com?userId=3a43ec976d7f513c2bd3e3019041edf8c12c016056dc22074d25c7907abb93fc"
+                      className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <MdLiveTv className="text-white" size={30} />
+                      <span className="text-white">ライブチャット</span>
+                    </a>
+                  </li> */}
+                  <li>
+                    <a
+                      href="https://go.rmhfrtnd.com?userId=3a43ec976d7f513c2bd3e3019041edf8c12c016056dc22074d25c7907abb93fc"
+                      className="flex items-center gap-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <MdLiveTv className="text-white" size={30} />
+                      <span className="flex items-center gap-1 whitespace-nowrap text-sm text-white">
+                        {t('liveChat')}
+                        <span className="rounded-full bg-red-600 px-2 py-0.5 text-xs text-white">
+                          {t('onSale')}
+                        </span>
                       </span>
-                    </span>
-                  </a>
-                </li>
+                    </a>
+                  </li>
 
-                <li>
-                  <a
-                    href="/"
-                    className="flex items-center gap-2 space-x-2 rounded p-2  hover:bg-gray-700"
-                  >
-                    <IoMdHome className="text-white" size={30} />
-                    <div className="text-white">おすすめ</div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="/like-video-list"
-                    className="flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <IoIosHeart className="text-white" size={30} />
-                    <span className="text-white">いいねした動画</span>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="/twitter-video-save"
-                    className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <IoMdSave className="text-white" size={30} />
-                    <span className="text-white">動画保存</span>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="/policy"
-                    className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <IoIosBook className="text-white" size={30} />
-                    <span className="text-white">規約・免責事項・ポリシー</span>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="/dmca"
-                    className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <IoIosBook className="text-white" size={30} />
-                    <span className="text-white">DMCA</span>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="/usc2257"
-                    className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
-                  >
-                    <IoIosBook className="text-white" size={30} />
-                    <span className="text-white">18 USC 2257 Statement</span>
-                  </a>
-                </li>
-              </ul>
+                  <li>
+                    <a
+                      href="/"
+                      className="flex items-center gap-2 space-x-2 rounded p-2  hover:bg-gray-700"
+                    >
+                      <IoMdHome className="text-white" size={30} />
+                      <div className="text-white">{t('recommended')}</div>
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="/like-video-list"
+                      className="flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <IoIosHeart className="text-white" size={30} />
+                      <span className="text-white">{t('likedVideos')}</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="/twitter-video-save"
+                      className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <IoMdSave className="text-white" size={30} />
+                      <span className="text-white">{t('videoSave')}</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="/policy"
+                      className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <IoIosBook className="text-white" size={30} />
+                      <span className="text-white">{t('policy')}</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="/dmca"
+                      className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <IoIosBook className="text-white" size={30} />
+                      <span className="text-white">{t('dmca')}</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="/usc2257"
+                      className=" flex items-center gap-2 space-x-2 rounded p-2 hover:bg-gray-700"
+                    >
+                      <IoIosBook className="text-white" size={30} />
+                      <span className="text-white">{t('usc2257')}</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div className="mb-4 mt-4 flex justify-center">
+                <button
+                  onClick={toggleLang}
+                  className="rounded border border-white px-3 py-1 text-sm text-white"
+                >
+                  {t('langSwitch')}
+                </button>
+              </div>
             </div>
           </motion.aside>
         )}

--- a/src/components/ui/TabNavigation.tsx
+++ b/src/components/ui/TabNavigation.tsx
@@ -2,32 +2,34 @@ import { SidebarMenu } from "@/components/ui/SideBarMenu";
 import { appUrl } from "@/config/url";
 import { NavLink } from "react-router-dom";
 import logo from "@/components/ui/xroll.png";
+import { useLanguage } from "@/utils/LanguageContext";
 
 export function TabNavigation() {
+  const { t } = useLanguage();
   return (
     <div className="fixed top-0 left-0 z-50 flex w-full items-center justify-center gap-10 p-4 font-bold text-white">
       <SidebarMenu />
       <img src={logo} alt="Xroll Logo" className="text-left" />
-      <NavLink
-        to={appUrl.mainVideoList}
+        <NavLink
+          to={appUrl.mainVideoList}
         className={({ isActive }) =>
           `border-b-2 focus:outline-none ${
             isActive ? "border-white" : "border-transparent"
           }`
         }
-      >
-        おすすめ
-      </NavLink>
-      <NavLink
-        to={appUrl.likeVideoList}
+        >
+          {t('recommended')}
+        </NavLink>
+        <NavLink
+          to={appUrl.likeVideoList}
         className={({ isActive }) =>
           `border-b-2 focus:outline-none ${
             isActive ? "border-white" : "border-transparent"
           }`
         }
-      >
-        いいねした動画
-      </NavLink>
+        >
+          {t('likedVideos')}
+        </NavLink>
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "@/App";
+import { LanguageProvider } from "@/utils/LanguageContext";
 import "@/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </React.StrictMode>,
 );

--- a/src/utils/LanguageContext.tsx
+++ b/src/utils/LanguageContext.tsx
@@ -1,0 +1,87 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type Lang = "ja" | "en";
+
+type LanguageContextType = {
+  lang: Lang;
+  toggleLang: () => void;
+  t: (key: string) => string;
+};
+
+const translations: Record<Lang, Record<string, string>> = {
+  ja: {
+    liveChat: "ライブチャット",
+    onSale: "セール中",
+    recommended: "おすすめ",
+    likedVideos: "いいねした動画",
+    videoSave: "動画保存",
+    policy: "規約・免責事項・ポリシー",
+    dmca: "DMCA",
+    usc2257: "18 USC 2257 Statement",
+    noLikedVideos: "いいねした動画はありません",
+    twitterSaveTool: "Twitter動画保存ツール",
+    tweetUrlPlaceholder: "ここにツイートのURLを入力",
+    fetch: "取得",
+    fetching: "動画を取得中です。しばらくお待ちください...",
+    fetchedVideo: "取得した動画",
+    note: "※ 当サイトは動画ファイルを直接保存しているわけではなく、Twitterに投稿された動画へのリンクを提供しています。",
+    privacyPolicy: "プライバシーポリシー",
+    contact: "お問い合わせ：xroll.net@gmail.com",
+    langSwitch: "English",
+  },
+  en: {
+    liveChat: "Live Chat",
+    onSale: "On Sale",
+    recommended: "Recommended",
+    likedVideos: "Liked Videos",
+    videoSave: "Video Save",
+    policy: "Terms & Policy",
+    dmca: "DMCA",
+    usc2257: "18 USC 2257 Statement",
+    noLikedVideos: "No liked videos",
+    twitterSaveTool: "Twitter Video Save Tool",
+    tweetUrlPlaceholder: "Paste tweet URL here",
+    fetch: "Fetch",
+    fetching: "Fetching video. Please wait...",
+    fetchedVideo: "Fetched Video",
+    note: "This site does not store videos directly; it only provides links to videos posted on Twitter.",
+    privacyPolicy: "Privacy Policy",
+    contact: "Contact: xroll.net@gmail.com",
+    langSwitch: "日本語",
+  },
+};
+
+const LanguageContext = createContext<LanguageContextType>({
+  lang: "ja",
+  toggleLang: () => {},
+  t: (key: string) => key,
+});
+
+export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
+  const [lang, setLang] = useState<Lang>("ja");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("lang") as Lang | null;
+    if (stored === "ja" || stored === "en") {
+      setLang(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("lang", lang);
+  }, [lang]);
+
+  const toggleLang = () => {
+    setLang((prev) => (prev === "ja" ? "en" : "ja"));
+  };
+
+  const t = (key: string) => translations[lang][key] || key;
+
+  return (
+    <LanguageContext.Provider value={{ lang, toggleLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);


### PR DESCRIPTION
## Summary
- add LanguageContext with translations for JP/EN
- wrap app in LanguageProvider
- translate main UI labels and add toggle at sidebar bottom
- update footer text and Twitter video save tool labels
- translate liked videos empty-state message

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d92f53ebc8326a96fde703638a0a8